### PR TITLE
feat(nowcoder): add platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Currently supported platforms:
 - [Lyrio](https://jsr.io/@un-oj/core/doc/platforms/lyrio) (LibreOJ) (`/platforms/lyrio`)
 - [Luogu](https://jsr.io/@un-oj/core/doc/platforms/luogu) (`/platforms/luogu`)
 - [MXOJ](https://jsr.io/@un-oj/core/doc/platforms/mxoj) (`/platforms/mxoj`)
+- [NowCoder](https://jsr.io/@un-oj/core/doc/platforms/nowcoder) (`/platforms/nowcoder`)
 
 Documents are available on [JSR](https://jsr.io/@un-oj/core/doc).
 

--- a/jsr.json
+++ b/jsr.json
@@ -11,7 +11,8 @@
     "./platforms/leetcode": "./src/platforms/leetcode.ts",
     "./platforms/lyrio": "./src/platforms/lyrio.ts",
     "./platforms/luogu": "./src/platforms/luogu.ts",
-    "./platforms/mxoj": "./src/platforms/mxoj.ts"
+    "./platforms/mxoj": "./src/platforms/mxoj.ts",
+    "./platforms/nowcoder": "./src/platforms/nowcoder.ts"
   },
   "publish": {
     "include": [

--- a/src/platforms/nowcoder.ts
+++ b/src/platforms/nowcoder.ts
@@ -1,0 +1,133 @@
+/**
+ * [NowCoder](https://ac.nowcoder.com) platform (ACM problem set).
+ * @module
+ */
+
+import type { PlatformOptions } from '../platform.ts';
+import type { Problem as BaseProblem, ProblemDescriptionObject, ProblemIOSample } from '../problem.ts';
+import { load } from 'cheerio';
+import { NotFoundError, Platform } from '../platform.ts';
+
+/**
+ * NowCoder-specific problem type.
+ *
+ * Description is a {@link ProblemDescriptionObject} because NowCoder separates
+ * the statement into 题目描述 / 输入描述 / 输出描述 sections in the HTML.
+ *
+ * - `timeLimit` is the C/C++/Rust/Pascal limit in ms (the first/strictest value
+ *   shown on the page; NowCoder shows language-dependent limits like
+ *   "C/C++/Rust/Pascal 1 秒，其他语言 2 秒" — we take the first).
+ * - `memoryLimit` is the C/C++/Rust/Pascal limit in bytes (same rule).
+ * - `tags` is `undefined`: NowCoder loads tags dynamically via JS, they are not
+ *   in the server-rendered HTML.
+ * - `difficulty` is `undefined`: not exposed on the problem page.
+ * - `type` is always `'traditional'`: NowCoder does not mark interactive /
+ *   communication problems in the static HTML.
+ */
+export type Problem = BaseProblem<
+  ProblemDescriptionObject,
+  number | undefined,
+  undefined,
+  undefined,
+  'traditional'
+>;
+
+export const DEFAULT_BASE_URL = 'https://ac.nowcoder.com';
+
+const MS_PER_SECOND = 1000;
+const MEMORY_UNITS: Record<string, number> = {
+  B: 1,
+  K: 1024,
+  KB: 1024,
+  M: 1024 * 1024,
+  MB: 1024 * 1024,
+  G: 1024 * 1024 * 1024,
+  GB: 1024 * 1024 * 1024,
+};
+
+/** NowCoder platform (ACM problem set on https://ac.nowcoder.com). */
+export default class NowCoder extends Platform {
+  constructor(options?: PlatformOptions) {
+    super(options, DEFAULT_BASE_URL);
+  }
+
+  /**
+   * Fetches a problem from NowCoder by parsing the ACM problem HTML page.
+   *
+   * @param id The numeric problem ID (e.g. `'16742'`).
+   */
+  override async getProblem(id: string): Promise<Problem> {
+    const path = `/acm/problem/${id}`;
+    const $ = load(await this.ofetch(path, { responseType: 'text' }));
+
+    const title = $('.question-title').text().trim();
+    if (!title)
+      throw new NotFoundError('problem');
+
+    // 题号 / 时间限制 / 空间限制 / IO 格式 都在 .subject-item-wrap 的纯文本里
+    const meta = $('.question-intr .subject-item-wrap').text();
+    const timeLimit = parseTimeLimit(meta);
+    const memoryLimit = parseMemoryLimit(meta);
+
+    const details = $('.subject-question').html() ?? '';
+    // <h2>输入描述:</h2> 紧跟 <pre>；用相邻兄弟选择器 + :contains 容忍全角/半角冒号
+    const input = $('.subject-describe h2:contains("输入描述") + pre').html() ?? '';
+    const output = $('.subject-describe h2:contains("输出描述") + pre').html() ?? '';
+
+    const samples: ProblemIOSample[] = [];
+    $('.question-oi').each((_, el) => {
+      const $sample = $(el);
+      // textarea 持有未编码的原始文本（复制按钮用），比解析 <pre> 更干净
+      const sampleInput = $sample.find('textarea[data-clipboard-text-id^="input"]').text();
+      const sampleOutput = $sample.find('textarea[data-clipboard-text-id^="output"]').text();
+      if (sampleInput || sampleOutput)
+        samples.push({ input: sampleInput, output: sampleOutput });
+    });
+
+    return {
+      id,
+      type: 'traditional',
+      title,
+      link: new URL(path, this.baseURL).href,
+      description: {
+        background: '',
+        details,
+        input,
+        output,
+        hint: '',
+      },
+      samples,
+      timeLimit,
+      memoryLimit,
+      tags: undefined,
+      difficulty: undefined,
+    };
+  }
+}
+
+/**
+ * 从 `.subject-item-wrap` 文本中解析 C/C++/Rust/Pascal 的时间限制（第一个值）。
+ *
+ * 形如 `时间限制：C/C++/Rust/Pascal 1 秒，其他语言 2 秒` → 1000 (ms)。
+ */
+function parseTimeLimit(s: string): number | undefined {
+  const m = s.match(/时间限制：[^\d，,]*(\d+)\s*秒/);
+  if (!m)
+    return undefined;
+  return Number(m[1]) * MS_PER_SECOND;
+}
+
+/**
+ * 从 `.subject-item-wrap` 文本中解析 C/C++/Rust/Pascal 的空间限制（第一个值）。
+ *
+ * 形如 `空间限制：C/C++/Rust/Pascal 128 M，其他语言 256 M` → 134217728 (bytes)。
+ */
+function parseMemoryLimit(s: string): number | undefined {
+  const m = s.match(/空间限制：[^\d，,]*(\d+)\s*([A-Z]+)/i);
+  if (!m || !m[2])
+    return undefined;
+  const unit = MEMORY_UNITS[m[2].toUpperCase()];
+  if (unit === undefined)
+    return undefined;
+  return Number(m[1]) * unit;
+}

--- a/tests/platforms/__snapshots__/nowcoder.spec.ts.snap
+++ b/tests/platforms/__snapshots__/nowcoder.spec.ts.snap
@@ -1,0 +1,70 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`NowCoder platform should fetch a stable problem (NOIP2002 字串变换) 1`] = `
+{
+  "description": {
+    "background": "",
+    "details": "已知有两个字串 A, B及一组字串变换的规则（至多6个规则）:<br> A<sub>1</sub> -&gt; B<sub>1</sub><br> A<sub>2</sub> -&gt;        B<sub>2</sub><br> 规则的含义为：在A中的子串 A<sub>1</sub>可以变换为 B<sub>1</sub>、A<sub>2</sub>可以变换为 B<sub>2</sub> …。<br> 例如：A＝'abcd'　B＝'xyz'<br> 变换规则为：<br> ‘abc’-&gt;‘xu’　‘ud’-&gt;‘y’　‘y’-&gt;‘yz’<br> 则此时，A        可以经过一系列的变换变为        B，其变换的过程为：<br> ‘abcd’-&gt;‘xud’-&gt;‘xy’-&gt;‘xyz’<br> 共进行了三次变换，使得A变换为B。",
+    "hint": "",
+    "input": "<div>输入格式如下：</div><div>A B<br></div><div>A<sub>1</sub> B<sub>1</sub> \\<br></div><div>A<sub>2</sub> B<sub>2</sub>&nbsp; |-&gt; 变换规则<br></div><div>... ... / <br></div><div>所有字符串长度的上限为 20。</div><div><br></div>",
+    "output": "输出格式如下：<br>若在10步（包含 10步）以内能将A变换为B，则输出最少的变换步数；否则输出"NO ANSWER!"",
+  },
+  "difficulty": undefined,
+  "id": "16742",
+  "link": "https://ac.nowcoder.com/acm/problem/16742",
+  "memoryLimit": 134217728,
+  "samples": [
+    {
+      "input": 
+"abcd xyz
+abc xu
+ud y
+y yz"
+,
+      "output": "3",
+    },
+  ],
+  "tags": undefined,
+  "timeLimit": 1000,
+  "title": "[NOIP2002]字串变换",
+  "type": "traditional",
+}
+`;
+
+exports[`NowCoder platform should fetch another stable problem 1`] = `
+{
+  "description": {
+    "background": "",
+    "details": "我们可以用这样的方式来表示一个十进制数： 将每个阿拉伯数字乘以一个以该数字所处位置的值减1为指数，以10为底数的幂之和的形式。例如：123可表示为 1*10<sup>2</sup>＋2*10<sup>1</sup>＋3*10<sup>0</sup>这样的形式。<br> 与之相似的，对二进制数来说，也可表示成每个二进制数码乘以一个以该数字所处位置的值-1为指数，以2为底数的幂之和的形式。一般说来，任何一个正整数Ｒ或一个负整数-Ｒ都可以被选来，作为一个数制系统的基数。如果是以Ｒ或-Ｒ为基数，则需要用到的数码为 0，1，．．．．Ｒ-1。例如，当Ｒ＝7时，所需用到的数码是0，1，2，3，4，5和6，这与其是Ｒ或-Ｒ无关。如果作为基数的数绝对值超过10，则为了表示这些数码，通常使用英文字母来表示那些大于9的数码。例如对16进制数来说，用Ａ表示10，用Ｂ表示11，用Ｃ表示12，用Ｄ表示13，用Ｅ表示14，用Ｆ表示15。<br> 在负进制数中是用-Ｒ 作为基数，例如-15(十进制)相当于110001(-2进制)，并且它可以被表示为2的幂级数的和数：<br> 110001＝1*(-2)<sup>5</sup>＋1*(-2)<sup>4</sup>＋0*(-2)<sup>3</sup>＋0*(-2)<sup>2</sup>＋0*(-2)<sup>1</sup> ＋1*(-2)<sup>0</sup><br> 设计一个程序，读入一个十进制数和一个负进制数的基数, 并将此十进制数转换为此负进制下的数：-Ｒ∈｛-2，-3，-4，．．．，-20｝<br>",
+    "hint": "",
+    "input": "第一个是十进制数N(-32768 ≤ N ≤ 32767)；  第二个是负进制数的基数-R。",
+    "output": "输出此负进制数及其基数，若此基数超过10，则参照16进制的方式处理。",
+  },
+  "difficulty": undefined,
+  "id": "16756",
+  "link": "https://ac.nowcoder.com/acm/problem/16756",
+  "memoryLimit": 268435456,
+  "samples": [
+    {
+      "input": "30000 -2",
+      "output": "30000=11011010101110000(base-2)",
+    },
+    {
+      "input": "-20000 -2",
+      "output": "-20000=1111011000100000(base-2)",
+    },
+    {
+      "input": "28800 -16",
+      "output": "28800=19180(base-16)",
+    },
+    {
+      "input": "-25000 -16",
+      "output": "-25000=7FB8(base-16)",
+    },
+  ],
+  "tags": undefined,
+  "timeLimit": 1000,
+  "title": "进制转换",
+  "type": "traditional",
+}
+`;

--- a/tests/platforms/nowcoder.spec.ts
+++ b/tests/platforms/nowcoder.spec.ts
@@ -1,0 +1,23 @@
+import { NotFoundError } from '@un-oj/core';
+import NowCoder from '@un-oj/core/platforms/nowcoder';
+import { describe, expect, it } from 'bun:test';
+import { assertProblem } from './utils.ts';
+
+const TIMEOUT = 10 * 1000;
+
+describe('NowCoder platform', () => {
+  const nc = new NowCoder();
+
+  it('should fetch a stable problem (NOIP2002 字串变换)', async () => {
+    assertProblem(await nc.getProblem('16742'));
+  }, TIMEOUT);
+
+  it('should fetch another stable problem', async () => {
+    assertProblem(await nc.getProblem('16756'));
+  }, TIMEOUT);
+
+  it('should throw NotFoundError w/ non-existent problem', async () => {
+    // NowCoder 对不存在的题目返回带错误提示的页面（无 .question-title），实现抛 NotFoundError
+    await expect(nc.getProblem('999999999')).rejects.toThrow(NotFoundError);
+  }, TIMEOUT);
+});


### PR DESCRIPTION
## What

Refs #3 (ticks the "NowCoder" checkbox; issue #3 stays open as a multi-platform checklist).

Adds a NowCoder (牛客竞赛, `ac.nowcoder.com`) platform adapter implementing `getProblem(id)` by parsing the ACM problem HTML page.

## Why

`#3` asks for more OJ platform coverage; NowCoder is one of the unchecked platforms and is widely used in the Chinese competitive-programming community. The last merged PR (#6, by GitHub Copilot) was another external contribution touching the platform adapters, so the contribution pattern is established.

## Changes

- `src/platforms/nowcoder.ts` (new): `NowCoder extends Platform` with `getProblem(id)`. Parses `.question-title` (title), `.subject-item-wrap` (time/memory limits — C/C++ value as canonical), `.subject-question` (description body), `<h2>输入描述</h2>+<pre>` / `<h2>输出描述</h2>+<pre>` (input/output format), and `.question-oi` blocks with `<textarea>` (sample I/O). Returns a `ProblemDescriptionObject` to preserve NowCoder's section separation. `getContest`/`listContests` remain unsupported (base-class default), matching the `lyrio` precedent.
- `tests/platforms/nowcoder.spec.ts` (new): fetches two stable problems (`16742`, `16756`) via `assertProblem` (which `toMatchSnapshot`), plus a non-existent-problem rejection test. 10s timeout per test, matching `codeforces.spec.ts`.
- `tests/platforms/__snapshots__/nowcoder.spec.ts.snap` (new, auto-generated): committed snapshot.
- `jsr.json`: add `"./platforms/nowcoder"` to `exports` (JSR requires explicit entries; this also serves as a `tsdown` build entry point per `tsdown.config.ts`).
- `README.md`: add NowCoder bullet to the platform list.

`package.json` is untouched — its wildcard `"./platforms/*": "./dist/platforms/*.js"` already covers the npm export.

## Backward compatibility

Pure addition. No existing platform or public API is modified. `package.json` is untouched (wildcard export). No new dependencies (`cheerio` already used by `codeforces.ts`). The new `jsr.json` export entry is additive.

## Out of scope (follow-up PRs welcome)

- `getContest` / `listContests` for NowCoder (contest pages have a different, more volatile structure).
- NowCoder tags (loaded via JS, not in server-rendered HTML — would need a separate API call).
- UI / consumer integration.

## Verification

Ran from a clean checkout on branch `feat/nowcoder-platform`:

- `bun run lint` ✅ exit 0
- `bun run type-check` ✅ exit 0
- `bun run test` — NowCoder tests: 3 pass / 0 fail (snapshot generated and committed). Full suite at verification time: 28 pass / 1 todo / 13 fail (the 13 failures are all pre-existing, see below).

Pristine-HEAD pre-existing failures (NOT caused by this PR — verified by running the full suite on `main` before any changes; the same hydro/codeforces/luogu failures reproduce on pristine `main`). Note: un-oj's test suite hits live network for all platforms, so individual failure counts may fluctuate by ±1-2 between runs due to external site rate-limiting and API drift — the 3 new NowCoder tests are the only delta introduced by this PR:

- `tests/platforms/hydro.spec.ts` — 7 failures, all rooted in `403 Forbidden` from `hydro.ac` (external site blocking requests): 5 surface as direct `FetchError: 403`, and 2 (`should throw NotFoundError w/ non-existent problem/domain`) surface as assertion mismatches because the 403 is wrapped into `UnOJError` instead of the expected `NotFoundError`. Not a code issue.
- `tests/platforms/codeforces.spec.ts` — 1 failure: `Codeforces platform (contest list) > should fetch a stable contest` — `FetchError: 400 Bad Request` from `codeforces.com/api/contest.standings?contestId=1`. Not a code issue.
- `tests/platforms/luogu.spec.ts` — 5 failures: `Luogu platform (problem) > should work` (snapshot content drift — Luogu changed the rendered problem content), `Luogu platform (contest) > should work` ("Cannot find contest"), and 3 `Luogu platform (contest list)` failures (2 "Failed to fetch contest list", 1 "Cannot find contest"). All caused by upstream Luogu API/HTML changes, not this PR.

The 3 new passing tests are exactly the NowCoder tests added by this PR. No pre-existing failure was worsened or newly introduced.

## Notes

- NowCoder returns HTTP 200 with an error page (no `.question-title`) for non-existent problems; the adapter throws `NotFoundError` via the title check, matching the `codeforces` content-check pattern (no `ofetch` wrapping needed).
- Conventional commit: `feat(nowcoder): add platform`.
- Uses `Refs #3` (not `Resolves`) so the multi-platform checklist issue #3 stays open for the remaining unchecked platforms.
