### PR TITLE
fix: correct "Compatibility" misspellings in error message and README heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Currently supported platforms:
 
 Documents are available on [JSR](https://jsr.io/@un-oj/core/doc).
 
-## Compataility
+## Compatibility
 
 UnOJ uses internal APIs, or parses HTML from some OJ, which may be changed at
 any time. If you encountered any problems, feel free to open an issue.

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -103,6 +103,6 @@ export class NotFoundError extends UnOJError {
 
 export class UnexpectedResponseError extends UnOJError {
   constructor(public data?: unknown) {
-    super('Unexpected response, see the "Compabtibility" section of README.md of @un-oj/core (or un-oj) package.');
+    super('Unexpected response, see the "Compatibility" section of README.md of @un-oj/core (or un-oj) package.');
   }
 }


### PR DESCRIPTION
## What

Fixes two misspellings of "Compatibility".

## Why

`UnexpectedResponseError` (src/platform.ts:106) tells the user to see the
`"Compabtibility"` section of README.md, but:

- the message itself misspells it as `Compabtibility` (extra `b`), and
- the README section it points to is misspelled *differently* as `## Compataility`.

So the pointer and the target are both wrong, and inconsistent with each
other — a user following the error message cannot find the section. Fixing
both makes the error message actually navigable.

## Changes

- `src/platform.ts:106` — `Compabtibility` → `Compatibility`
- `README.md:40` — `## Compataility` → `## Compatibility`

Docs-only / string-only change. No behavior, API, or dependency change.

## Verification

- `grep -rnE "Compab|Compata" . --exclude-dir=node_modules --exclude-dir=.git` returns 0 matches after the fix (was 2 before).
- No test asserts on the literal error string (`grep -rn UnexpectedResponseError tests/` → 0 matches), so no snapshot update needed.
- `bun run lint` and `bun run type-check` both pass (string-content-only change).
