### PR TITLE
fix: use JSON import attributes for tsdown config and version export

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import type { HeadersInit } from 'bun';
+import pkg from '../package.json' with { type: 'json' };
 
-export { version } from '../package.json' with { type: 'json' };
+export const version: string = pkg.version;
 
 /** Get the first key of an object. */
 export function getFirstKey<T extends Record<never, never>>(obj: T): keyof T {

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'tsdown';
-import { exports } from './jsr.json';
+import jsr from './jsr.json' with { type: 'json' };
 
 export default defineConfig({
-  entry: Object.values(exports),
+  entry: Object.values(jsr.exports),
 });


### PR DESCRIPTION
## Summary

Restores `bun run build` after the `tsdown 0.14.1` upgrade. The build was failing because the upgraded toolchain (rolldown + rolldown-plugin-dts) enforces stricter JSON module import attributes and can no longer resolve a bare re-export of a named JSON export.

## Root cause

`tsdown 0.14.1` (which uses `rolldown` under the hood) now requires explicit `with { type: 'json' }` import attributes on JSON module imports, and `rolldown-plugin-dts` can no longer resolve a bare `export { x } from './foo.json' with { type: 'json' }` re-export when emitting `.d.ts` files. Two surfaces were affected:

- **`tsdown.config.ts`** — `import { exports } from './jsr.json';` (no import attribute) fails at config-load time with `ERR_IMPORT_ATTRIBUTE_MISSING: Module ".../jsr.json" needs an import attribute of "type: json"`.
- **`src/utils.ts`** — `export { version } from '../package.json' with { type: 'json' };` (bare re-export) fails at `.d.ts` emit time with `Cannot resolve import '../package.json' from '.../src/utils.d.ts'`.

Both failures block `bun run build` from producing `dist/`.

## Changes

| File | Change |
| --- | --- |
| `tsdown.config.ts` | Switch `import { exports } from './jsr.json'` → `import jsr from './jsr.json' with { type: 'json' }`, then access `jsr.exports`. JSON modules only expose a default export, so the original named import was incorrect under stricter ESM resolution. |
| `src/utils.ts` | Replace `export { version } from '../package.json' with { type: 'json' };` (bare re-export, unresolvable by `rolldown-plugin-dts`) with `import pkg from '../package.json' with { type: 'json' }; export const version: string = pkg.version;`. Preserves the public type signature (`string`). |

## Why both files in one PR

The build does not pass unless **both** changes are applied. Splitting into two PRs would ship a still-broken build between them, which is worse than a single coherent fix. The two changes share the same root trigger (the `tsdown 0.14.1` upgrade) even though the failure mode differs between them.

## Verification

```
bun run build         # exit 0 — 20 files emitted to dist/
bun run type-check    # exit 0 (tsc --noEmit)
bun run lint          # exit 0 — clean (0 warnings, 0 errors)
```

I also reproduced the original failure by checking out the parent commit (`31a02ef`) in a throwaway worktree and confirmed both failure modes (config-load failure for `tsdown.config.ts`, then `.d.ts` resolution failure for `src/utils.ts` after fixing only the config).

## Backward compatibility

- No runtime behavior change; `version` retains type `string` (verified by type probe — the original `export { version } from '../package.json'` produced type `string`, not the literal `"0.3.2"`, so the new annotation is a strict no-op for callers).
- `version` is consumed only internally in `src/platform.ts` (for the `User-Agent` header); it is **not** re-exported from `dist/index.d.ts`, so there is no public-API impact.

## Out of scope

- No `CHANGELOG.md` entry — per `CONTRIBUTING.md` "Releasing", the changelog is written as part of the `release: v{version}` commit, not per-PR.
- No version bump (this is a build fix, not a release).
- No test changes (build-config-only fix; no behavioral change to test).
- No changes to other JSON imports — Grep confirms `tsdown.config.ts` and `src/utils.ts` are the only JSON imports in the repo's `.ts`/`.js`/`.mts`/`.cts` files.
