### PR TITLE
feat(spoj): add platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Currently supported platforms:
 - [Lyrio](https://jsr.io/@un-oj/core/doc/platforms/lyrio) (LibreOJ) (`/platforms/lyrio`)
 - [Luogu](https://jsr.io/@un-oj/core/doc/platforms/luogu) (`/platforms/luogu`)
 - [MXOJ](https://jsr.io/@un-oj/core/doc/platforms/mxoj) (`/platforms/mxoj`)
+- [SPOJ](https://jsr.io/@un-oj/core/doc/platforms/spoj) (Sphere Online Judge) (`/platforms/spoj`)
 
 Documents are available on [JSR](https://jsr.io/@un-oj/core/doc).
 

--- a/jsr.json
+++ b/jsr.json
@@ -11,7 +11,8 @@
     "./platforms/leetcode": "./src/platforms/leetcode.ts",
     "./platforms/lyrio": "./src/platforms/lyrio.ts",
     "./platforms/luogu": "./src/platforms/luogu.ts",
-    "./platforms/mxoj": "./src/platforms/mxoj.ts"
+    "./platforms/mxoj": "./src/platforms/mxoj.ts",
+    "./platforms/spoj": "./src/platforms/spoj.ts"
   },
   "publish": {
     "include": [

--- a/src/platforms/spoj.ts
+++ b/src/platforms/spoj.ts
@@ -98,10 +98,13 @@ export default class SPOJ extends Platform {
 
     // Description: the problem body HTML minus the title, tags, info table and
     // the "Information" heading. Samples remain inline (see type JSDoc above).
+    // The info table is targeted via the preceding `<h3>Information</h3>` so
+    // that any tables in the statement itself are preserved.
     body.find('h2').first().remove();
     body.find('a[href*="/problems/tag/"]').closest('p').remove();
-    body.find('table').remove();
-    body.find('h3').filter((_, el) => $(el).text().trim() === 'Information').remove();
+    const infoHeading = body.find('h3').filter((_, el) => $(el).text().trim() === 'Information');
+    infoHeading.next('table').remove();
+    infoHeading.remove();
     const description = body.html()?.trim();
     if (!description)
       throw new NotFoundError('statement');
@@ -144,7 +147,10 @@ function parseTimeLimit(s?: string): number | undefined {
   const m = s.match(/([\d.]+)\s*s/i);
   if (!m)
     return undefined;
-  return Math.round(Number(m[1]) * MS_PER_SECOND);
+  const n = Number(m[1]);
+  if (!Number.isFinite(n))
+    return undefined;
+  return Math.round(n * MS_PER_SECOND);
 }
 
 /**
@@ -162,7 +168,10 @@ function parseMemoryLimit(s?: string): number | undefined {
   const unit = MEMORY_UNITS[m[2].toUpperCase()];
   if (unit === undefined)
     return undefined;
-  return Math.round(Number(m[1]) * unit);
+  const n = Number(m[1]);
+  if (!Number.isFinite(n))
+    return undefined;
+  return Math.round(n * unit);
 }
 
 /**

--- a/src/platforms/spoj.ts
+++ b/src/platforms/spoj.ts
@@ -1,0 +1,197 @@
+/**
+ * [SPOJ](https://www.spoj.com) (Sphere Online Judge) platform.
+ * @module
+ */
+
+import type { PlatformOptions } from '../platform.ts';
+import type { Problem as BaseProblem, ProblemIOSample } from '../problem.ts';
+import { load } from 'cheerio';
+import { FetchError } from 'ofetch';
+import { NotFoundError, Platform } from '../platform.ts';
+import { UnOJError } from '../utils.ts';
+
+/**
+ * SPOJ-specific problem type.
+ *
+ * - Description is the HTML of the problem body (statement + example). Samples
+ *   are also kept inline in the description because SPOJ embeds them in the
+ *   statement; they are additionally parsed into {@link Problem.samples}.
+ * - `timeLimit` is in milliseconds, parsed from the info table (e.g. `1s`).
+ * - `memoryLimit` is in bytes, parsed from the info table (e.g. `1536MB`).
+ * - `tags` are the `#tag` links on the page (without the leading `#`).
+ * - `difficulty` is `undefined`: SPOJ only exposes percentage-based concept /
+ *   implementation difficulty, not a stable rating.
+ * - `type` is always `'traditional'`: SPOJ does not mark interactive /
+ *   communication problems in the static HTML.
+ */
+export type Problem = BaseProblem<
+  string,
+  number | undefined,
+  undefined,
+  string[],
+  'traditional'
+>;
+
+export const DEFAULT_BASE_URL = 'https://www.spoj.com';
+
+/** SPOJ (Sphere Online Judge) platform. */
+export default class SPOJ extends Platform {
+  constructor(options?: PlatformOptions) {
+    super(options, DEFAULT_BASE_URL);
+  }
+
+  /**
+   * Fetches a problem from SPOJ by scraping the problem page at
+   * `/problems/<id>/`. SPOJ has no JSON API, so the page HTML is parsed.
+   *
+   * @param id The problem code, e.g. `'TEST'`.
+   */
+  override async getProblem(id: string): Promise<Problem> {
+    const path = `/problems/${id}/`;
+    const url = new URL(path, this.baseURL).href;
+
+    let html: string;
+    try {
+      html = await this.ofetch(path, { responseType: 'text' });
+    } catch (e) {
+      if (e instanceof FetchError && e.statusCode === 404)
+        throw new NotFoundError('problem');
+      throw new UnOJError(`Failed to fetch problem ${id}`, { cause: e });
+    }
+
+    const $ = load(html);
+    const body = $('#problem-body');
+    if (!body.length)
+      throw new NotFoundError('problem');
+
+    // Title is "<ID> - <title>" in the first <h2> of the problem body.
+    const rawTitle = body.find('h2').first().text().trim();
+    if (!rawTitle)
+      throw new NotFoundError('problem');
+    const title = rawTitle.includes(' - ')
+      ? rawTitle.slice(rawTitle.indexOf(' - ') + 3)
+      : rawTitle;
+
+    // Tags are the "#tag" links inside the problem body.
+    const tags: string[] = body
+      .find('a[href*="/problems/tag/"]')
+      .map((_, el) => $(el).text().trim().replace(/^#/, ''))
+      .get();
+
+    // Time / memory limits live in the info table rows:
+    // `<th>Time limit:</th><td>1s</td>` / `<th>Memory limit:</th><td>1536MB</td>`.
+    const info: Record<string, string> = {};
+    body.find('table tr').each((_, tr) => {
+      const $tr = $(tr);
+      const label = $tr.find('th').text().trim().replace(/:$/, '');
+      const value = $tr.find('td').text().trim();
+      if (label)
+        info[label] = value;
+    });
+    const timeLimit = parseTimeLimit(info['Time limit']);
+    const memoryLimit = parseMemoryLimit(info['Memory limit']);
+
+    // Samples: each <pre> typically contains "Input:\n...\n\nOutput:\n...".
+    const samples = parseSamples(
+      body.find('pre').map((_, el) => $(el).text()).get(),
+    );
+
+    // Description: the problem body HTML minus the title, tags, info table and
+    // the "Information" heading. Samples remain inline (see type JSDoc above).
+    body.find('h2').first().remove();
+    body.find('a[href*="/problems/tag/"]').closest('p').remove();
+    body.find('table').remove();
+    body.find('h3').filter((_, el) => $(el).text().trim() === 'Information').remove();
+    const description = body.html()?.trim();
+    if (!description)
+      throw new NotFoundError('statement');
+
+    return {
+      id,
+      type: 'traditional',
+      title,
+      link: url,
+      description,
+      samples,
+      timeLimit,
+      memoryLimit,
+      tags,
+      difficulty: undefined,
+    };
+  }
+}
+
+const MS_PER_SECOND = 1000;
+const MEMORY_UNITS: Record<string, number> = {
+  B: 1,
+  K: 1024,
+  KB: 1024,
+  M: 1024 * 1024,
+  MB: 1024 * 1024,
+  G: 1024 * 1024 * 1024,
+  GB: 1024 * 1024 * 1024,
+};
+
+/**
+ * Parses a SPOJ time limit string like `1s` or `1.5s` into milliseconds.
+ *
+ * @param s The time limit string from the info table.
+ * @returns The time in milliseconds, or undefined if failed.
+ */
+function parseTimeLimit(s?: string): number | undefined {
+  if (!s)
+    return undefined;
+  const m = s.match(/([\d.]+)\s*s/i);
+  if (!m)
+    return undefined;
+  return Math.round(Number(m[1]) * MS_PER_SECOND);
+}
+
+/**
+ * Parses a SPOJ memory limit string like `1536MB` or `256M` into bytes.
+ *
+ * @param s The memory limit string from the info table.
+ * @returns The memory in bytes, or undefined if failed.
+ */
+function parseMemoryLimit(s?: string): number | undefined {
+  if (!s)
+    return undefined;
+  const m = s.match(/([\d.]+)\s*([A-Z]+)/i);
+  if (!m || !m[2])
+    return undefined;
+  const unit = MEMORY_UNITS[m[2].toUpperCase()];
+  if (unit === undefined)
+    return undefined;
+  return Math.round(Number(m[1]) * unit);
+}
+
+/**
+ * Parses sample input/output pairs from `<pre>` block texts.
+ *
+ * A `<pre>` is treated as a sample when it contains `Input:` / `Output:`
+ * labels; pres without those labels (e.g. code in the statement) are skipped.
+ *
+ * @param pres The text contents of each `<pre>` in the problem body.
+ * @returns The parsed sample input/output pairs.
+ */
+function parseSamples(pres: string[]): ProblemIOSample[] {
+  const samples: ProblemIOSample[] = [];
+  for (const pre of pres) {
+    const inputIdx = pre.search(/Input:/i);
+    const outputIdx = pre.search(/Output:/i);
+    if (inputIdx === -1 && outputIdx === -1)
+      continue;
+    let input = '';
+    let output = '';
+    if (inputIdx !== -1 && outputIdx !== -1 && inputIdx < outputIdx) {
+      input = pre.slice(inputIdx + 6, outputIdx);
+      output = pre.slice(outputIdx + 7);
+    } else if (inputIdx !== -1) {
+      input = pre.slice(inputIdx + 6);
+    } else {
+      output = pre.slice(outputIdx + 7);
+    }
+    samples.push({ input: input.trim(), output: output.trim() });
+  }
+  return samples;
+}

--- a/tests/platforms/__snapshots__/spoj.spec.ts.snap
+++ b/tests/platforms/__snapshots__/spoj.spec.ts.snap
@@ -1,0 +1,50 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`SPOJ platform should fetch a stable problem (TEST) 1`] = `
+{
+  "description": 
+"<p>Your program is to use the brute-force approach in order to <em>find the Answer to Life, the Universe, and Everything</em>. More precisely... rewrite small numbers from input to output. Stop processing input after reading in the number 42. All numbers at input are integers of one or two digits.</p>
+<h3>Example</h3>
+<pre>Input:
+1
+2
+88
+42
+99
+
+Output:
+1
+2
+88</pre>
+<br>"
+,
+  "difficulty": undefined,
+  "id": "TEST",
+  "link": "https://www.spoj.com/problems/TEST/",
+  "memoryLimit": 1610612736,
+  "samples": [
+    {
+      "input": 
+"1
+2
+88
+42
+99"
+,
+      "output": 
+"1
+2
+88"
+,
+    },
+  ],
+  "tags": [
+    "basic",
+    "tutorial",
+    "ad-hoc-1",
+  ],
+  "timeLimit": 1000,
+  "title": "Life, the Universe, and Everything",
+  "type": "traditional",
+}
+`;

--- a/tests/platforms/spoj.spec.ts
+++ b/tests/platforms/spoj.spec.ts
@@ -1,0 +1,79 @@
+import { NotFoundError } from '@un-oj/core';
+import SPOJ from '@un-oj/core/platforms/spoj';
+import { describe, expect, it } from 'bun:test';
+import { assertProblem } from './utils.ts';
+
+// SPOJ is fronted by a Cloudflare managed challenge that 403s non-browser
+// clients (curl / ofetch), so the live-HTTP + snapshot pattern used by the
+// other platform tests is not viable here. Instead we drive the adapter with a
+// fake underlying `fetch` (via `ofetchCreateOptions.fetch`) that returns a
+// canned HTML fixture modeled on a real SPOJ problem page. See NOTES.md.
+
+// Minimal, faithful reconstruction of `https://www.spoj.com/problems/TEST/`.
+const TEST_HTML = `<!DOCTYPE html>
+<html lang="en-US">
+<head><title>SPOJ.com - Problem TEST</title></head>
+<body>
+<ol class="breadcrumb">
+<li><a href="/problems">Problems</a></li>
+<li><a href="/problems/classical">classical</a></li>
+<li class="active">Life, the Universe, and Everything</li>
+</ol>
+<div id="problem-body" class="col-md-12">
+<h2 id="problem-name" class="text-center">TEST - Life, the Universe, and Everything</h2>
+<p class="text-center">
+<a href="/problems/tag/basic">#basic</a>
+<a href="/problems/tag/tutorial">#tutorial</a>
+<a href="/problems/tag/ad-hoc-1">#ad-hoc-1</a>
+</p>
+<p>Your program is to use the brute-force approach in order to <em>find the Answer to Life, the Universe, and Everything</em>. More precisely... rewrite small numbers from input to output. Stop processing input after reading in the number 42. All numbers at input are integers of one or two digits.</p>
+<h3>Example</h3>
+<pre>Input:
+1
+2
+88
+42
+99
+
+Output:
+1
+2
+88</pre>
+<br/>
+<h3>Information</h3>
+<table class="table table-condensed">
+<tr><th>Added by:</th><td><a href="/users/mima">mima</a></td></tr>
+<tr><th>Date:</th><td>2004-05-01</td></tr>
+<tr><th>Time limit:</th><td>1s</td></tr>
+<tr><th>Source limit:</th><td>50000B</td></tr>
+<tr><th>Memory limit:</th><td>1536MB</td></tr>
+<tr><th>Cluster:</th><td><a href="/clusters/">Cube (Intel G860)</a></td></tr>
+<tr><th>Languages:</th><td>All</td></tr>
+<tr><th>Resource:</th><td>Douglas Adams, The Hitchhiker's Guide to the Galaxy</td></tr>
+</table>
+</div>
+</body>
+</html>`;
+
+/** Builds a SPOJ instance whose underlying `fetch` serves `html` (or a 404 for `notFoundId`). */
+function makeSpoj(html: string, notFoundId?: string): SPOJ {
+  const fakeFetch = ((...args: Parameters<typeof fetch>): Promise<Response> => {
+    const url = String(args[0]);
+    if (notFoundId && url.includes(`/problems/${notFoundId}/`))
+      return Promise.resolve(new Response('', { status: 404, statusText: 'Not Found' }));
+    return Promise.resolve(new Response(html, { status: 200, headers: { 'content-type': 'text/html; charset=utf-8' } }));
+  }) as typeof fetch;
+  return new SPOJ({ ofetchCreateOptions: { fetch: fakeFetch } });
+}
+
+describe('SPOJ platform', () => {
+  it('should fetch a stable problem (TEST)', async () => {
+    const spoj = makeSpoj(TEST_HTML);
+    assertProblem(await spoj.getProblem('TEST'));
+  });
+
+  it('should throw NotFoundError w/ non-existent problem', async () => {
+    const spoj = makeSpoj(TEST_HTML, 'NONEXISTENT');
+    await expect(spoj.getProblem('NONEXISTENT')).rejects.toThrow(NotFoundError);
+  });
+});

--- a/tests/platforms/spoj.spec.ts
+++ b/tests/platforms/spoj.spec.ts
@@ -1,5 +1,6 @@
 import { NotFoundError } from '@un-oj/core';
 import SPOJ from '@un-oj/core/platforms/spoj';
+import { UnOJError } from '@un-oj/core/utils';
 import { describe, expect, it } from 'bun:test';
 import { assertProblem } from './utils.ts';
 
@@ -7,7 +8,7 @@ import { assertProblem } from './utils.ts';
 // clients (curl / ofetch), so the live-HTTP + snapshot pattern used by the
 // other platform tests is not viable here. Instead we drive the adapter with a
 // fake underlying `fetch` (via `ofetchCreateOptions.fetch`) that returns a
-// canned HTML fixture modeled on a real SPOJ problem page. See NOTES.md.
+// canned HTML fixture modeled on a real SPOJ problem page.
 
 // Minimal, faithful reconstruction of `https://www.spoj.com/problems/TEST/`.
 const TEST_HTML = `<!DOCTYPE html>
@@ -55,15 +56,19 @@ Output:
 </body>
 </html>`;
 
+/** Builds a SPOJ instance with a custom underlying `fetch`. */
+function makeSpojWithFetch(fetchImpl: typeof fetch): SPOJ {
+  return new SPOJ({ ofetchCreateOptions: { fetch: fetchImpl } });
+}
+
 /** Builds a SPOJ instance whose underlying `fetch` serves `html` (or a 404 for `notFoundId`). */
 function makeSpoj(html: string, notFoundId?: string): SPOJ {
-  const fakeFetch = ((...args: Parameters<typeof fetch>): Promise<Response> => {
+  return makeSpojWithFetch(((...args: Parameters<typeof fetch>): Promise<Response> => {
     const url = String(args[0]);
     if (notFoundId && url.includes(`/problems/${notFoundId}/`))
       return Promise.resolve(new Response('', { status: 404, statusText: 'Not Found' }));
     return Promise.resolve(new Response(html, { status: 200, headers: { 'content-type': 'text/html; charset=utf-8' } }));
-  }) as typeof fetch;
-  return new SPOJ({ ofetchCreateOptions: { fetch: fakeFetch } });
+  }) as typeof fetch);
 }
 
 describe('SPOJ platform', () => {
@@ -75,5 +80,31 @@ describe('SPOJ platform', () => {
   it('should throw NotFoundError w/ non-existent problem', async () => {
     const spoj = makeSpoj(TEST_HTML, 'NONEXISTENT');
     await expect(spoj.getProblem('NONEXISTENT')).rejects.toThrow(NotFoundError);
+  });
+
+  // Cloudflare managed-challenge pages return 200 with JS-challenge HTML that
+  // has no `#problem-body`; the adapter should surface this as NotFoundError.
+  it('should throw NotFoundError when #problem-body is missing (e.g. Cloudflare challenge)', async () => {
+    const spoj = makeSpoj('<!DOCTYPE html><html><body><h1>Just a moment...</h1></body></html>');
+    await expect(spoj.getProblem('TEST')).rejects.toThrow(NotFoundError);
+  });
+
+  it('should throw UnOJError on non-404 fetch failure (e.g. HTTP 500)', async () => {
+    const spoj = makeSpojWithFetch(((..._args: Parameters<typeof fetch>): Promise<Response> =>
+      Promise.resolve(new Response('', { status: 500, statusText: 'Internal Server Error' }))) as typeof fetch);
+    await expect(spoj.getProblem('TEST')).rejects.toThrow(UnOJError);
+    await expect(spoj.getProblem('TEST')).rejects.not.toThrow(NotFoundError);
+  });
+
+  it('should throw NotFoundError when title is missing', async () => {
+    const spoj = makeSpoj('<div id="problem-body"><p>statement without a heading</p></div>');
+    await expect(spoj.getProblem('TEST')).rejects.toThrow(NotFoundError);
+  });
+
+  it('should throw NotFoundError when description is missing', async () => {
+    // #problem-body has a title but nothing else; after the title is stripped,
+    // the description is empty.
+    const spoj = makeSpoj('<div id="problem-body"><h2>TEST - Title</h2></div>');
+    await expect(spoj.getProblem('TEST')).rejects.toThrow(NotFoundError);
   });
 });


### PR DESCRIPTION
## Summary

Adds SPOJ (Sphere Online Judge, https://www.spoj.com) platform adapter by HTML-scraping problem pages at `https://www.spoj.com/problems/<ID>/`. Follows the same pattern as the existing HTML-scraping adapters (e.g. `atcoder.ts`, `codeforces.ts`).

Refs #3 (SPOJ checkbox).

## What's included

- `src/platforms/spoj.ts` (new, 206 LOC) — `SPOJ` class extending `Platform`, implementing `getProblem(id)` by scraping `https://www.spoj.com/problems/<ID>/`. Extracts title, statement (HTML), time/memory limits, tags, and samples. Throws `NotFoundError` on 404 or missing required fields; wraps other errors in `UnOJError`.
- `tests/platforms/spoj.spec.ts` (new) — 6 tests: (1) fetch a stable problem (`TEST`) with snapshot, (2) `NotFoundError` on a non-existent problem, (3) `NotFoundError` when `#problem-body` is missing (Cloudflare-challenge scenario), (4) `UnOJError` on non-404 fetch failure (HTTP 500), (5) `NotFoundError` when title is missing, (6) `NotFoundError` when description is missing. Injects a fake `fetch` via `PlatformOptions.ofetchCreateOptions.fetch` to stub the HTTP layer (new pattern, introduced because SPOJ is behind Cloudflare's managed challenge — every other adapter test in the repo uses live HTTP, which is not viable here).
- `tests/platforms/__snapshots__/spoj.spec.ts.snap` (new) — snapshot of the parsed `TEST` problem.
- `jsr.json` — added `./platforms/spoj` export.
- `README.md` — added SPOJ entry to "Currently supported platforms".

## Implementation notes

- No new dependencies — uses the existing `cheerio` + `ofetch` already in the project.
- Does **not** migrate `ofetch` → native `fetch` (that's #4, separate PR scope).
- `listContests()` / `getContest()` left as default `UnsupportedError` — SPOJ has no public contest listing API and no other scraper-based adapter in the repo implements `listContests` either.
- Custom `parseTimeLimit`/`parseMemoryLimit`/`parseSamples` helpers added because SPOJ uses `1s`/`1536MB` format not covered by `src/utils.ts` helpers. Kept private to the adapter to avoid leaking SPOJ-specific parsing into shared utils.
- `parseSamples` uses `String.search` + `String.slice` (not capture-group regex) to satisfy the `regexp/no-super-linear-backtracking` ESLint ReDoS rule that the project enforces.

## Testing

- `bun run type-check` (`tsc --noEmit`) — clean
- `bun run lint` (`eslint .`) — clean
- `bun test tests/platforms/spoj.spec.ts` — 6 pass, 0 fail

## Caveats

- **SPOJ is behind Cloudflare managed challenge.** `curl` and direct `ofetch` requests get the challenge HTML / 403. The adapter code is correct against the page structure assumed from inspection of `https://www.spoj.com/problems/TEST/`, but live-HTTP tests cannot be exercised from CI. Tests therefore inject a fake `fetch` (new pattern in this repo) returning canned HTML modeled on the actual page.
- This relates to #10 (CI live tests) — SPOJ spec passes locally with the fake-`fetch` pattern introduced in this PR.

## Checklist

- [x] Code follows existing platform adapter conventions
- [x] Tests added and pass locally
- [x] Type-check passes
- [x] Lint passes
- [x] No new dependencies added
- [x] README updated
- [x] jsr.json export added
- [x] Commit message uses conventional commits format
- [x] No unrelated changes; no temp files
