### PR TITLE
fix(codeforces): drop count param from contest.standings

### DIFF
--- a/src/platforms/codeforces.ts
+++ b/src/platforms/codeforces.ts
@@ -105,9 +105,11 @@ export default class Codeforces extends Platform {
 
     let response: any;
     try {
+      // Codeforces' contest.standings API rejects any extra query params for
+      // non-admin users with HTTP 400, so we must not send `count` here.
       response = await this.ofetch('/api/contest.standings', {
         responseType: 'json',
-        query: { contestId, count: 1 },
+        query: { contestId },
       });
     } catch (e) {
       throw new UnOJError(`Failed to fetch contest ${id}`, { cause: e });


### PR DESCRIPTION
## What

Fixes `Codeforces.getContest(id)` by removing the `count: 1` query parameter from the `/api/contest.standings` request.

## Why

`Codeforces.getContest` is currently broken for **every** caller. The Codeforces `contest.standings` API now rejects any extra query parameters for non-admin users with HTTP 400:

> `{"status":"FAILED","comment":"contestId: Non-gym contest standings for non-admin users are available only via anonymous GET requests with no extra parameters: https://codeforces.com/api/contest.standings?contestId=<id>"}`

The adapter was sending `query: { contestId, count: 1 }`; the `count: 1` is what triggers the 400 — verified by hitting the API with `contestId` ∈ {1, 5, 50, 100, 1000, 599}: **all** return 400 with `count=1`, and **all** return 200 without it. Dropping `count` restores `getContest` for all contest IDs.

This also fixes the one Codeforces test failure tracked in #10 — but note this is **not** the "test-data problem" #10's follow-up comment diagnosed it as. Swapping `contestId=1` for another contest wouldn't have helped, because the 400 is triggered by the `count` param, not the contestId. Contest 1's snapshot is correct and unchanged.

## Changes

- `src/platforms/codeforces.ts`: drop `count: 1` from the `contest.standings` query in `getContest`. One-line behavioral change + a comment explaining the API constraint.

No test changes needed — the existing `(contest list) > should fetch a stable contest` snapshot for contest 1 still matches the API response.

## Verification

- `bun run lint` ✅
- `bun run type-check` ✅
- `bun test tests/platforms/codeforces.spec.ts` → 8 pass / 1 todo / 0 fail (previously 7 pass / 1 todo / 1 fail).
- Spot-checked `getContest('5')` returns a populated `Contest`.

## Scope

Intentionally narrow. This is a real user-facing bug (`getContest` broken for all callers) independent of the #10 CI-direction discussion. The remaining 12 live-network failures in #10 are unaffected and belong to the Option A/B conversation there.

---

_Note: I'm an AI agent operating the `Luyicheng-Agent` account (previously disclosed in #8 and #10). If you'd rather not take AI-authored contributions, no problem — just say so._
